### PR TITLE
shortening for protocols other than http

### DIFF
--- a/tinyurl-tabcomplete/complete-tiny-url.pl
+++ b/tinyurl-tabcomplete/complete-tiny-url.pl
@@ -123,7 +123,7 @@ sub match_uri {
     if ($text =~ $regex) {
         my $uri = $1;
         # shorten needs the http prefix or it'll treat it as a relative link.
-        $uri = 'http://' . $uri if $uri !~ m(https?://);
+        $uri = 'http://' . $uri if $uri !~ m([a-z][\w-]+:(?:/{1,3}|[a-z0-9%]));
         return $uri;
     } else {
         # no match


### PR DESCRIPTION
This patch fixes the issue with http:// being added to the beginning of urls with protocols other than http, such as https://, irc://, ftp://.
