### PR TITLE
Fix use of uninitialized value

### DIFF
--- a/history-search/rl_history_search.pl
+++ b/history-search/rl_history_search.pl
@@ -396,9 +396,10 @@ sub next_match {
 
 sub update_input {
     my $match = get_history_match();
-    # TODO: Use of uninitialized value in subroutine entry at /Users/shabble/projects/tmp/test/irssi-shab/scripts/rl_history_search.pl line 399.
-    Irssi::gui_input_set($match); # <--- here.
-	Irssi::gui_input_set_pos(length $match);
+    if ($match) {
+        Irssi::gui_input_set($match);
+        Irssi::gui_input_set_pos(length $match);
+    }
 }
 
 sub handle_keypress {


### PR DESCRIPTION
When looking up search-matches, the $match variable may be used
uninitialized. A simple check before the use avoids that.

Signed-off-by: hjan <hoeppner.jan@xurv.org>