### PR TITLE
Update uberprompt

### DIFF
--- a/prompt_info/uberprompt.pl
+++ b/prompt_info/uberprompt.pl
@@ -316,7 +316,7 @@ my $init_callbacks = {load => '', unload => ''};
 pre_init();
 
 sub pre_init {
-    Irssi::command('statusbar prompt reset');
+    `stty -ixon`;
     init();
 }
 
@@ -393,11 +393,9 @@ sub deinit {
     Irssi::expando_destroy('lbrace');
     Irssi::expando_destroy('rbrace');
 
-    if (Irssi::settings_get_bool('uberprompt_restore_on_exit')) {
-        # remove uberprompt and return the original ones.
-        print "Removing uberprompt and restoring original";
-        restore_prompt_items();
-    }
+    # remove uberprompt and return the original ones.
+    #print "Removing uberprompt and restoring original";
+    restore_prompt_items();
 }
 
 sub init {
@@ -415,7 +413,6 @@ sub init {
 
     Irssi::settings_add_bool('uberprompt', 'uberprompt_debug', 0);
     Irssi::settings_add_bool('uberprompt', 'uberprompt_autostart', 1);
-    Irssi::settings_add_bool ('uberprompt', 'uberprompt_restore_on_exit', 1);
 
     Irssi::settings_add_bool('uberprompt', 'uberprompt_use_replaces', 0);
     Irssi::settings_add_bool('uberprompt', 'uberprompt_trim_data', 0);
@@ -705,18 +702,15 @@ sub uberprompt_refresh {
 }
 
 sub replace_prompt_items {
+    # add the new one.
+    _sbar_command('prompt', 'add', 'uberprompt',
+                  qw/-alignment left -after prompt_empty -priority '-1'/);
+
     # remove existing ones.
     _debug_print("Removing original prompt");
 
     _sbar_command('prompt', 'remove', 'prompt');
     _sbar_command('prompt', 'remove', 'prompt_empty');
-
-    # add the new one.
-
-    _sbar_command('prompt', 'add', 'uberprompt',
-                  qw/-alignment left -before input -priority '-1'/);
-
-    _sbar_command('prompt', 'position', '100');
 
     my $load_hook = $init_callbacks->{load};
     if (defined $load_hook and length $load_hook) {
@@ -732,11 +726,14 @@ sub replace_prompt_items {
 
 sub restore_prompt_items {
 
-    _sbar_command('prompt', 'remove', 'uberprompt');
-
     _debug_print("Restoring original prompt");
 
-    _sbar_command('prompt', 'reset');
+    _sbar_command('prompt', 'add', 'prompt',
+                  qw/-alignment left -after uberprompt -priority '-1'/);
+    _sbar_command('prompt', 'add', 'prompt_empty',
+                  qw/-alignment left -after prompt -priority '-1'/);
+
+    _sbar_command('prompt', 'remove', 'uberprompt');
 
     my $unload_hook = $init_callbacks->{unload};
 

--- a/prompt_info/uberprompt.pl
+++ b/prompt_info/uberprompt.pl
@@ -398,6 +398,10 @@ sub deinit {
     restore_prompt_items();
 }
 
+sub gui_exit {
+    die; # unload script
+}
+
 sub init {
     Irssi::statusbar_item_register('uberprompt', 0, 'uberprompt_draw');
 
@@ -431,6 +435,7 @@ sub init {
 
     Irssi::command_bind('help', \&_print_help);
 
+    Irssi::signal_add_first('gui exit', \&gui_exit);
     Irssi::signal_add('setup changed', \&reload_settings);
 
     # intialise the prompt format.

--- a/prompt_info/uberprompt.pl
+++ b/prompt_info/uberprompt.pl
@@ -399,7 +399,7 @@ sub deinit {
 }
 
 sub gui_exit {
-    die; # unload script
+    restore_prompt_items();
 }
 
 sub init {
@@ -706,7 +706,12 @@ sub uberprompt_refresh {
     Irssi::statusbar_items_redraw('uberprompt');
 }
 
+my $prompt_items_replaced;
+
 sub replace_prompt_items {
+    unless ($prompt_items_replaced) {
+    $prompt_items_replaced = 1;
+
     # add the new one.
     _sbar_command('prompt', 'add', 'uberprompt',
                   qw/-alignment left -after prompt_empty -priority '-1'/);
@@ -716,6 +721,8 @@ sub replace_prompt_items {
 
     _sbar_command('prompt', 'remove', 'prompt');
     _sbar_command('prompt', 'remove', 'prompt_empty');
+
+    }
 
     my $load_hook = $init_callbacks->{load};
     if (defined $load_hook and length $load_hook) {
@@ -730,6 +737,8 @@ sub replace_prompt_items {
 }
 
 sub restore_prompt_items {
+    if ($prompt_items_replaced) {
+    $prompt_items_replaced = undef;
 
     _debug_print("Restoring original prompt");
 
@@ -739,6 +748,8 @@ sub restore_prompt_items {
                   qw/-alignment left -after prompt -priority '-1'/);
 
     _sbar_command('prompt', 'remove', 'uberprompt');
+
+    }
 
     my $unload_hook = $init_callbacks->{unload};
 


### PR DESCRIPTION
Do not reset prompt sbar in uberprompt
- Resetting the prompt sbar is annoying as it removes any items in it. Don't do that.
  Enable Ctrl-S by default
- Prompt-using scripts also like this key
