### PR TITLE
Update ido_switcher

### DIFF
--- a/ido-mode/ido_switcher.pl
+++ b/ido-mode/ido_switcher.pl
@@ -308,11 +308,14 @@ my $MODE = MODE_WIN;
 
 # check we have uberprompt loaded.
 
+my %need_clear;
+
 sub _print {
     my $win = Irssi::active_win;
     my $str = join('', @_);
     $need_clear = 1;
     $win->print($str, MSGLEVEL_NEVER);
+    push @{ $need_clear{ $win->{_irssi} } }, $win->view->{buffer}{cur_line};
 }
 
 sub _debug_print {
@@ -324,8 +327,18 @@ sub _debug_print {
 
 sub _print_clear {
     return unless $need_clear;
-    my $win = Irssi::active_win();
-    $win->command('/^scrollback levelclear -level NEVER');
+    for my $win (Irssi::windows) {
+	if (my $lines = delete $need_clear{ $win->{_irssi} }) {
+	    my $view = $win->view;
+	    my $bottom = $view->{bottom};
+	    for my $line (@$lines) {
+		$view->remove_line($line);
+	    }
+	    $win->command('^scrollback end') if $bottom && !$win->view->{bottom};
+	    $view->redraw;
+	}
+    }
+    %need_clear=();
 }
 
 # TODO: use the code from rl_history_search to put this into a disposable
@@ -342,7 +355,7 @@ sub display_help {
        '%_Ctrl-r%_   - rotate the list of window candidates backward by 1',
        '%_Ctrl-e%_   - Toggle \'Active windows only\' filter',
        '%_Ctrl-f%_   - Switch between \'Flex\' and \'Exact\' matching.',
-       '%_Ctrl-d%_   - Select a network or server to filter candidates by',
+#       '%_Ctrl-d%_   - Select a network or server to filter candidates by',
        '%_Ctrl-u%_   - Clear the current search string',
        '%_Ctrl-q%_   - Cycle between showing only queries, channels, or all.',
        '%_Ctrl-SPC%_ - Filter candidates by current search string, and then ',
@@ -375,7 +388,7 @@ sub print_all_matches {
 
     # Also, colourise the channel list.
 
-    my $col_width;
+    my $col_width = 1;
 
     for (@search_matches) {
         my $len = length($_->{name});
@@ -405,34 +418,14 @@ sub print_all_matches {
     #_print("Longtest name: $longest_name");
 }
 
-sub script_is_loaded {
-    return exists($Irssi::Script::{$_[0] . '::'});
-}
+unless ("Irssi::Script::uberprompt"->can('init')) {
 
-unless (script_is_loaded('uberprompt')) {
+    print "Warning, this script requires '\%_uberprompt.pl\%_' in order to work. ";
 
-    _print "This script requires '\%_uberprompt.pl\%_' in order to work. "
-      . "Attempting to load it now...";
-
-    Irssi::signal_add('script error', 'load_uberprompt_failed');
-    Irssi::command("script load uberprompt.pl");
-
-    unless(script_is_loaded('uberprompt')) {
-        load_uberprompt_failed("File does not exist");
-    }
-    ido_switch_init();
-}
-
-sub load_uberprompt_failed {
-    Irssi::signal_remove('script error', 'load_uberprompt_failed');
-    _print "Script could not be loaded. Script cannot continue. "
-        . "Check you have uberprompt.pl installed in your path and "
-        .  "try again.";
-    die "Script Load Failed: " . join(" ", @_);
 }
 
 sub ido_switch_init {
-    Irssi::settings_add_bool('ido_switch', 'ido_switch_debug',      0);
+    #Irssi::settings_add_bool('ido_switch', 'ido_switch_debug',      0);
     Irssi::settings_add_bool('ido_switch', 'ido_use_flex',          1);
     Irssi::settings_add_bool('ido_switch', 'ido_show_active_first', 1);
     Irssi::settings_add_int ('ido_switch', 'ido_show_count',        5);
@@ -448,7 +441,7 @@ sub ido_switch_init {
 }
 
 sub setup_changed {
-    $DEBUG_ENABLED     = Irssi::settings_get_bool('ido_switch_debug');
+    #$DEBUG_ENABLED     = Irssi::settings_get_bool('ido_switch_debug');
     $ido_show_count    = Irssi::settings_get_int ('ido_show_count');
     $ido_use_flex      = Irssi::settings_get_bool('ido_use_flex');
     $sort_active_first = Irssi::settings_get_bool('ido_show_active_first');
@@ -468,7 +461,7 @@ sub ido_switch_start {
     my @opts = Irssi::command_parse_options($CMD_NAME, $args);
     if (@opts and ref($opts[0]) eq 'HASH') {
         $options = $opts[0];
-        print "Options: " . Dumper($options);
+        #print "Options: " . Dumper($options);
     }
 
     # clear / initialise match variables.
@@ -569,522 +562,542 @@ sub get_all_windows {
 
 }
 
-    sub _sort_windows {
-        my $list_ref = shift;
-        my @ret = @$list_ref;
+sub _sort_windows {
+    my $list_ref = shift;
+    my @ret = @$list_ref;
 
-        @ret = sort { $a->{num} <=> $b->{num}  } @ret;
-        if ($sort_active_first) {
-            my @active   = grep {     $_->{active} } @ret;
-            my @inactive = grep { not $_->{active} } @ret;
+    @ret = sort { $a->{num} <=> $b->{num}  } @ret;
+    if ($sort_active_first) {
+        my @active   = grep {     $_->{active} } @ret;
+        my @inactive = grep { not $_->{active} } @ret;
 
-            return (@active, @inactive);
-        } else {
-            return @ret;
-        }
+        return (@active, @inactive);
+    } else {
+        return @ret;
+    }
+}
+
+sub ido_switch_select {
+    my ($selected, $tag) = @_;
+    if (!$selected) {
+	_debug_print "Error, selection invalid";
+	return;
+    }
+    _debug_print sprintf("Selecting window: %s (%d)",
+                         $selected->{name}, $selected->{num});
+
+    Irssi::command("WINDOW GOTO " . $selected->{num});
+
+    if ($selected->{type} ne 'WIN') {
+        _debug_print "Selecting window item: " . $selected->{itemname};
+        Irssi::command("WINDOW ITEM GOTO " . $selected->{itemname});
     }
 
-    sub ido_switch_select {
-        my ($selected, $tag) = @_;
+    update_matches();
+}
 
-        _debug_print sprintf("Selecting window: %s (%d)",
-                             $selected->{name}, $selected->{num});
+sub ido_switch_exit {
+    $ido_switch_active = 0;
 
-        Irssi::command("WINDOW GOTO " . $selected->{num});
+    _print_clear();
 
-        if ($selected->{type} ne 'WIN') {
-            _debug_print "Selecting window item: " . $selected->{itemname};
-            Irssi::command("WINDOW ITEM GOTO " . $selected->{itemname});
-        }
+    Irssi::gui_input_set($input_copy);
+    Irssi::gui_input_set_pos($input_pos_copy);
+    Irssi::signal_emit('change prompt', '', 'UP_INNER');
+}
 
-        update_matches();
-    }
+sub _order_matches {
+    return @_[$match_index .. $#_,
+              0            .. $match_index - 1]
+}
 
-    sub ido_switch_exit {
-        $ido_switch_active = 0;
+sub update_window_select_prompt {
 
-        _print_clear();
+    # take the top $ido_show_count entries and display them.
+    my $match_count  = scalar @search_matches;
+    my $show_count   = $ido_show_count;
+    my $match_string = '[No matches]';
 
-        Irssi::gui_input_set($input_copy);
-        Irssi::gui_input_set_pos($input_pos_copy);
-        Irssi::signal_emit('change prompt', '', 'UP_INNER');
-    }
+    $show_count = $match_count if $match_count < $show_count;
 
-    sub _order_matches {
-        return @_[$match_index .. $#_,
-                  0            .. $match_index - 1]
-    }
+    if ($show_count > 0) { # otherwise, default message above.
+        _debug_print "Showing: $show_count matches";
 
-    sub update_window_select_prompt {
+        my @ordered_matches = _order_matches(@search_matches);
 
-        # take the top $ido_show_count entries and display them.
-        my $match_count  = scalar @search_matches;
-        my $show_count   = $ido_show_count;
-        my $match_string = '[No matches]';
+        my @display = @ordered_matches[0..$show_count - 1];
 
-        $show_count = $match_count if $match_count < $show_count;
+        # determine which items are non-unique, if any.
 
-        if ($show_count > 0) { # otherwise, default message above.
-            _debug_print "Showing: $show_count matches";
+        my %uniq;
 
-            my @ordered_matches = _order_matches(@search_matches);
+        foreach my $res (@display) {
+            my $name = $res->{name};
 
-            my @display = @ordered_matches[0..$show_count - 1];
-
-            # determine which items are non-unique, if any.
-
-            my %uniq;
-
-            foreach my $res (@display) {
-                my $name = $res->{name};
-
-                if (exists $uniq{$name}) {
-                    push @{$uniq{$name}}, $res;
-                } else {
-                    $uniq{$name} = [];
-                    push @{$uniq{$name}}, $res;
-                }
-            }
-
-            # and set a flag to ensure they have their network tag applied
-            # to them when drawn.
-            foreach my $name (keys %uniq) {
-                my @values = @{$uniq{$name}};
-                if (@values > 1) {
-                    $_->{display_net} = 1 for @values;
-                }
-            }
-
-            # show the first entry in green
-
-            my $first = shift @display;
-            my $formatted_first = _format_display_entry($first, '%g');
-            unshift @display, $formatted_first;
-
-            # and array-slice-map the rest to be red.
-            # or yellow, if they have unviewed activity
-
-            @display[1..$#display]
-              = map
-              {
-                  _format_display_entry($_, $_->{active}?'%y':'%r')
-
-              } @display[1..$#display];
-
-            # join em all up
-            $match_string = join ', ', @display;
-        }
-
-        my @indicators;
-
-        # indicator if flex mode is being used (C-f to toggle)
-        push @indicators, $ido_use_flex ? 'Flex' : 'Exact';
-        push @indicators, 'Active' if $active_only;
-        push @indicators, ucfirst(lc($mode_type));
-
-        my $flex = sprintf(' %%b[%%n%s%%b]%%n ', join ', ', @indicators);
-
-        my $search = '';
-        $search = (sprintf '`%s\': ', $search_str) if length $search_str;
-
-        Irssi::signal_emit('change prompt', $flex . $search . $match_string,
-                           'UP_INNER');
-    }
-
-
-
-    sub _format_display_entry {
-        my ($obj, $colour) = @_;
-
-        my $field     = $obj->{hilight_field};
-        my $hilighted = { name => $obj->{name}, num => $obj->{num} };
-        my $show_tag  = $obj->{display_net} || 0;
-
-        if ($obj->{b_pos} >= 0 && $obj->{e_pos} > $obj->{b_pos}) {
-            substr($hilighted->{$field}, $obj->{e_pos}, 0) = '%_';
-            substr($hilighted->{$field}, $obj->{b_pos}, 0) = '%_';
-            _debug_print "Showing $field as: " . $hilighted->{$field}
-        }
-
-        return sprintf('%s%s:%s%s%%n',
-                       $colour,
-                       $hilighted->{num},
-                       $show_tag ? _format_display_tag($obj) : '',
-                       $hilighted->{name});
-    }
-
-    sub _format_display_tag {
-        my $obj = shift;
-        if (defined $obj->{server}) {
-            my $server = $obj->{server};
-            my $tag = $server->{tag};
-            return $tag . '/' if length $tag;
-        }
-        return '';
-    }
-
-    sub _check_active {
-        my ($obj) = @_;
-        return 1 unless $active_only;
-        return $obj->{active};
-    }
-
-    sub update_matches {
-
-        _update_cache() unless $search_str;
-
-        if ($mode_type ne 'ALL') {
-            @mode_cache = @window_cache;
-            @window_cache = grep { $_->{type} eq $mode_type } @window_cache;
-        } else {
-            @window_cache = @mode_cache if @mode_cache;
-        }
-
-        if ($search_str =~ m/^\d+$/) {
-
-            @search_matches =
-              grep {
-                  _check_active($_) and regex_match($_, 'num')
-              } @window_cache;
-
-        } elsif ($ido_use_flex) {
-
-            @search_matches =
-              grep {
-                  _check_active($_) and flex_match($_) >= 0
-              } @window_cache;
-
-        } else {
-
-            @search_matches =
-              grep {
-                  _check_active($_) and regex_match($_, 'name')
-              } @window_cache;
-        }
-
-    }
-
-    sub regex_match {
-        my ($obj, $field) = @_;
-        if ($obj->{$field} =~ m/^(.*?)\Q$search_str\E(.*?)$/i) {
-            $obj->{hilight_field} = $field;
-            $obj->{b_pos} = length $1;
-            $obj->{e_pos} = $obj->{b_pos} + length($search_str);
-            return 1;
-        }
-        return 0;
-    }
-
-    sub flex_match {
-        my ($obj) = @_;
-
-        my $pattern = $search_str;
-        my $source  = $obj->{name};
-
-        _debug_print "Flex match: $pattern / $source";
-
-        # default to matching everything if we don't have a pattern to compare
-        # against.
-
-        return 0 unless $pattern;
-
-        my @chars = split '', lc($pattern);
-        my $ret = -1;
-        my $first = 0;
-
-        my $lc_source = lc($source);
-
-        $obj->{hilight_field} = 'name';
-
-        foreach my $char (@chars) {
-            my $pos = index($lc_source, $char, $ret);
-            if ($pos > -1) {
-
-                # store the beginning of the match
-                $obj->{b_pos} = $pos unless $first;
-                $first = 1;
-
-                _debug_print("matched: $char at $pos in $source");
-                $ret = $pos + 1;
-
+            if (exists $uniq{$name}) {
+                push @{$uniq{$name}}, $res;
             } else {
-
-                $obj->{b_pos} = $obj->{e_pos} = -1;
-                _debug_print "Flex returning: -1";
-
-                return -1;
+                $uniq{$name} = [];
+                push @{$uniq{$name}}, $res;
             }
         }
 
-        _debug_print "Flex returning: $ret";
-
-        #store the end of the match.
-        $obj->{e_pos} = $ret;
-
-        return $ret;
-    }
-
-    sub prev_match {
-
-        $match_index++;
-        if ($match_index > $#search_matches) {
-            $match_index = 0;
-        }
-
-        _debug_print "index now: $match_index";
-    }
-
-    sub next_match {
-
-        $match_index--;
-        if ($match_index < 0) {
-            $match_index = $#search_matches;
-        }
-        _debug_print "index now: $match_index";
-    }
-
-    sub get_window_match {
-        return $search_matches[$match_index];
-    }
-
-    sub handle_keypress {
-        my ($key) = @_;
-
-        return unless $ido_switch_active;
-
-        if ($showing_help) {
-            _print_clear();
-            $showing_help = 0;
-            Irssi::signal_stop();
-        }
-
-        if ($key == 0) {        # C-SPC?
-            _debug_print "\%_Ctrl-space\%_";
-
-            $search_str = '';
-            @window_cache = @search_matches;
-            update_window_select_prompt();
-
-            Irssi::signal_stop();
-            return;
-        }
-
-        if ($key == 3) {        # C-c
-            _print_clear();
-            Irssi::signal_stop();
-            return;
-        }
-        if ($key == 4) {        # C-d
-            update_network_select_prompt();
-            Irssi::signal_stop();
-            return;
-        }
-
-        if ($key == 5) {        # C-e
-            $active_only = not $active_only;
-            Irssi::signal_stop();
-            update_matches();
-            update_window_select_prompt();
-            return;
-        }
-
-        if ($key == 6) {        # C-f
-
-            $ido_use_flex = not $ido_use_flex;
-            _update_cache();
-
-            update_matches();
-            update_window_select_prompt();
-
-            Irssi::signal_stop();
-            return;
-        }
-        if ($key == 9) {        # TAB
-            _debug_print "Tab complete";
-            print_all_matches();
-            Irssi::signal_stop();
-        }
-
-        if ($key == 10) {       # enter
-            _debug_print "selecting history and quitting";
-            my $selected_win = get_window_match();
-            ido_switch_select($selected_win);
-
-            ido_switch_exit();
-            Irssi::signal_stop();
-            return;
-        }
-        if ($key == 11) { # Ctrl-K
-            my $sel = get_window_match();
-            _debug_print("deleting entry: " . $sel->{num});
-            Irssi::command("window close " . $sel->{num});
-            _update_cache();
-            update_matches();
-            update_window_select_prompt();
-            Irssi::signal_stop();
-
-        }
-
-        if ($key == 18) {       # Ctrl-R
-            _debug_print "skipping to prev match";
-            #update_matches();
-            next_match();
-
-            update_window_select_prompt();
-            Irssi::signal_stop(); # prevent the bind from being re-triggered.
-            return;
-        }
-
-        if ($key == 17) {       # Ctrl-q
-            if ($mode_type eq 'CHANNEL') {
-                $mode_type = 'QUERY';
-            } elsif ($mode_type eq 'QUERY') {
-                $mode_type = 'ALL';
-            } else { # ALL
-                $mode_type = 'CHANNEL';
+        # and set a flag to ensure they have their network tag applied
+        # to them when drawn.
+        foreach my $name (keys %uniq) {
+            my @values = @{$uniq{$name}};
+            if (@values > 1) {
+                $_->{display_net} = 1 for @values;
             }
-            update_matches();
-            update_window_select_prompt();
-            Irssi::signal_stop();
         }
 
-        if ($key == 19) {       # Ctrl-s
-            _debug_print "skipping to next match";
-            prev_match();
+        # show the first entry in green
 
-            #update_matches();
-            update_window_select_prompt();
+        my $first = shift @display;
+        my $formatted_first = _format_display_entry($first, '%g');
+        unshift @display, $formatted_first;
 
-            Irssi::signal_stop();
-            return;
+        # and array-slice-map the rest to be red.
+        # or yellow, if they have unviewed activity
+
+        @display[1..$#display]
+          = map
+          {
+              _format_display_entry($_, $_->{active}?'%y':'%r')
+
+          } @display[1..$#display];
+
+        # join em all up
+        $match_string = join ', ', @display;
+    }
+
+    my @indicators;
+
+    # indicator if flex mode is being used (C-f to toggle)
+    push @indicators, $ido_use_flex ? 'Flex' : 'Exact';
+    push @indicators, 'Active' if $active_only;
+    push @indicators, ucfirst(lc($mode_type));
+
+    my $flex = sprintf(' %%b[%%n%s%%b]%%n ', join ', ', @indicators);
+
+    my $search = '';
+    $search = (sprintf '`%s\': ', $search_str) if length $search_str;
+
+    Irssi::signal_emit('change prompt', $flex . $search . $match_string,
+                       'UP_INNER');
+}
+
+
+
+sub _format_display_entry {
+    my ($obj, $colour) = @_;
+
+    my $field     = $obj->{hilight_field};
+    my $hilighted = { name => $obj->{name}, num => $obj->{num} };
+    my $show_tag  = $obj->{display_net} || 0;
+
+    if ($obj->{b_pos} >= 0 && $obj->{e_pos} > $obj->{b_pos}) {
+        substr($hilighted->{$field}, $obj->{e_pos}, 0) = '%_';
+        substr($hilighted->{$field}, $obj->{b_pos}, 0) = '%_';
+        _debug_print "Showing $field as: " . $hilighted->{$field}
+    }
+
+    return sprintf('%s%s:%s%s%%n',
+                   $colour,
+                   $hilighted->{num},
+                   $show_tag ? _format_display_tag($obj) : '',
+                   $hilighted->{name});
+}
+
+sub _format_display_tag {
+    my $obj = shift;
+    if (defined $obj->{server}) {
+        my $server = $obj->{server};
+        my $tag = $server->{tag};
+        return $tag . '/' if length $tag;
+    }
+    return '';
+}
+
+sub _check_active {
+    my ($obj) = @_;
+    return 1 unless $active_only;
+    return $obj->{active};
+}
+
+sub update_matches {
+    my $current_match = get_window_match();
+
+    _update_cache() unless $search_str;
+
+    if ($mode_type ne 'ALL') {
+        @mode_cache = @window_cache;
+        @window_cache = grep { $_->{type} eq $mode_type } @window_cache;
+    } else {
+        @window_cache = @mode_cache if @mode_cache;
+    }
+
+    if ($search_str =~ m/^\d+$/) {
+
+        @search_matches =
+          grep {
+              _check_active($_) and regex_match($_, 'num')
+          } @window_cache;
+
+    } elsif ($ido_use_flex) {
+
+        @search_matches =
+          grep {
+              _check_active($_) and flex_match($_) >= 0
+          } @window_cache;
+
+    } else {
+
+        @search_matches =
+          grep {
+              _check_active($_) and regex_match($_, 'name')
+          } @window_cache;
+    }
+
+    $match_index = 0;
+    if ($current_match) {
+    for my $idx (0..$#search_matches) {
+	if ($search_matches[$idx]{num} == $current_match->{num}
+	   && $search_matches[$idx]{type} eq $current_match->{type}) {
+	    $match_index = $idx;
+	    if ($current_match->{type} eq 'WIN') {
+		last;
+	    } elsif ($search_matches[$idx]{itemname} eq $current_match->{itemname}) {
+		last;
+	    }
+	}
+    }
+    }
+
+}
+
+sub regex_match {
+    my ($obj, $field) = @_;
+    if ($obj->{$field} =~ m/^(.*?)\Q$search_str\E(.*?)$/i) {
+        $obj->{hilight_field} = $field;
+        $obj->{b_pos} = length $1;
+        $obj->{e_pos} = $obj->{b_pos} + length($search_str);
+        return 1;
+    }
+    return 0;
+}
+
+sub flex_match {
+    my ($obj) = @_;
+
+    my $pattern = $search_str;
+    my $source  = $obj->{name};
+
+    _debug_print "Flex match: $pattern / $source";
+
+    # default to matching everything if we don't have a pattern to compare
+    # against.
+
+    return 0 unless $pattern;
+
+    my @chars = split '', lc($pattern);
+    my $ret = -1;
+    my $first = 0;
+
+    my $lc_source = lc($source);
+
+    $obj->{hilight_field} = 'name';
+
+    foreach my $char (@chars) {
+        my $pos = index($lc_source, $char, $ret);
+        if ($pos > -1) {
+
+            # store the beginning of the match
+            $obj->{b_pos} = $pos unless $first;
+            $first = 1;
+
+            _debug_print("matched: $char at $pos in $source");
+            $ret = $pos + 1;
+
+        } else {
+
+            $obj->{b_pos} = $obj->{e_pos} = -1;
+            _debug_print "Flex returning: -1";
+
+            return -1;
         }
+    }
 
-        if ($key == 7) {        # Ctrl-g
-            _debug_print "aborting search";
-            ido_switch_exit();
-            Irssi::signal_stop();
-            return;
-        }
+    _debug_print "Flex returning: $ret";
 
-        if ($key == 8) {        # Ctrl-h
-            display_help();
-            Irssi::signal_stop();
-            return;
-        }
+    #store the end of the match.
+    $obj->{e_pos} = $ret;
 
-        if ($key == 21) {       # Ctrl-u
-            $search_str = '';
-            update_matches();
-            update_window_select_prompt();
+    return $ret;
+}
 
-            Irssi::signal_stop();
-            return;
+sub prev_match {
 
-        }
+    $match_index++;
+    if ($match_index > $#search_matches) {
+        $match_index = 0;
+    }
 
-        if ($key == 127) {      # DEL
+    _debug_print "index now: $match_index";
+}
 
-            if (length $search_str) {
-                $search_str = substr($search_str, 0, -1);
-                _debug_print "Deleting char, now: $search_str";
-            }
+sub next_match {
 
-            update_matches();
-            update_window_select_prompt();
+    $match_index--;
+    if ($match_index < 0) {
+        $match_index = $#search_matches;
+    }
+    _debug_print "index now: $match_index";
+}
 
-            Irssi::signal_stop();
-            return;
-        }
+sub get_window_match {
+    return $search_matches[$match_index];
+}
 
-        # TODO: handle esc- sequences and arrow-keys?
+sub handle_keypress {
+    my ($key) = @_;
 
-        if ($key == 27) {       # Esc
-            ido_switch_exit();
-            return;
-        }
+    return unless $ido_switch_active;
 
-        if ($key == 32) {       # space
-            my $selected_win = get_window_match();
-            ido_switch_select($selected_win);
-
-            prev_match();
-            update_window_select_prompt();
-
-            Irssi::signal_stop();
-
-            return;
-        }
-
-        if ($key > 32) {        # printable
-            $search_str .= chr($key);
-
-            update_matches();
-            update_window_select_prompt();
-
-            Irssi::signal_stop();
-            return;
-        }
-
-        # ignore all other keys.
+    if ($showing_help) {
+        _print_clear();
+        $showing_help = 0;
         Irssi::signal_stop();
     }
 
-    ido_switch_init();
+    if ($key == 0) {        # C-SPC?
+        _debug_print "\%_Ctrl-space\%_";
 
-    sub update_network_select_prompt {
+        $search_str = '';
+        @window_cache = @search_matches;
+        update_window_select_prompt();
 
-        my @servers = map
-          {
-              {
-                  name => $_->{tag},
-                  type => 'SERVER',
-                  active => 0,
-                  e_pos => -1,
-                  b_pos => -1,
-                  hilight_field => 'name',
-              }
-          } Irssi::servers();
+        Irssi::signal_stop();
+        return;
+    }
 
-        my $match_count  = scalar @servers;
-        my $show_count   = $ido_show_count;
-        my $match_string = '(no matches) ';
+    if ($key == 3) {        # C-c
+        _print_clear();
+        Irssi::signal_stop();
+        return;
+    }
+    if ($key == 4) {        # C-d
+#        update_network_select_prompt();
+        Irssi::signal_stop();
+        return;
+    }
 
-        $show_count = $match_count if $match_count < $show_count;
+    if ($key == 5) {        # C-e
+        $active_only = not $active_only;
+        Irssi::signal_stop();
+        update_matches();
+        update_window_select_prompt();
+        return;
+    }
 
-        if ($show_count > 0) {
-            _debug_print "Showing: $show_count matches";
+    if ($key == 6) {        # C-f
 
-            my @ordered_matches = _order_matches(@servers);
-            my @display = @ordered_matches[0..$show_count - 1];
+        $ido_use_flex = not $ido_use_flex;
+        _update_cache();
 
-            # show the first entry in green
+        update_matches();
+        update_window_select_prompt();
 
-            unshift(@display, _format_display_entry(shift(@display), '%g'));
+        Irssi::signal_stop();
+        return;
+    }
+    if ($key == 9) {        # TAB
+        _debug_print "Tab complete";
+	_print_clear();
+        print_all_matches();
+        Irssi::signal_stop();
+    }
 
-            # and array-slice-map the rest to be red (or yellow for active)
-            @display[1..$#display]
-              = map
-              {
-                  _format_display_entry($_, $_->{active}?'%y':'%r')
+    if ($key == 10) {       # enter
+        _debug_print "selecting history and quitting";
+        my $selected_win = get_window_match();
+        ido_switch_select($selected_win);
 
-              } @display[1..$#display];
-
-            # join em all up
-            $match_string = join ', ', @display;
-        }
-
-        my @indicators;
-
-        # indicator if flex mode is being used (C-f to toggle)
-        push @indicators, $ido_use_flex ? 'Flex' : 'Exact';
-        push @indicators, 'Active' if $active_only;
-
-        my $flex = sprintf(' %%k[%%n%s%%k]%%n ', join ',', @indicators);
-
-        my $search = '';
-        $search = (sprintf '`%s\': ', $search_str) if length $search_str;
-
-        Irssi::signal_emit('change prompt', $flex . $search . $match_string,
-                           'UP_INNER');
+        ido_switch_exit();
+        Irssi::signal_stop();
+        return;
+    }
+    if ($key == 11) { # Ctrl-K
+        my $sel = get_window_match();
+        _debug_print("deleting entry: " . $sel->{num});
+        Irssi::command("window close " . $sel->{num});
+        _update_cache();
+        update_matches();
+        update_window_select_prompt();
+        Irssi::signal_stop();
 
     }
+
+    if ($key == 18) {       # Ctrl-R
+        _debug_print "skipping to prev match";
+        #update_matches();
+        next_match();
+
+        update_window_select_prompt();
+        Irssi::signal_stop(); # prevent the bind from being re-triggered.
+        return;
+    }
+
+    if ($key == 17) {       # Ctrl-q
+        if ($mode_type eq 'CHANNEL') {
+            $mode_type = 'QUERY';
+        } elsif ($mode_type eq 'QUERY') {
+            $mode_type = 'ALL';
+        } else { # ALL
+            $mode_type = 'CHANNEL';
+        }
+        update_matches();
+        update_window_select_prompt();
+        Irssi::signal_stop();
+    }
+
+    if ($key == 19) {       # Ctrl-s
+        _debug_print "skipping to next match";
+        prev_match();
+
+        #update_matches();
+        update_window_select_prompt();
+
+        Irssi::signal_stop();
+        return;
+    }
+
+    if ($key == 7) {        # Ctrl-g
+        _debug_print "aborting search";
+        ido_switch_exit();
+        Irssi::signal_stop();
+        return;
+    }
+
+    if ($key == 8) {        # Ctrl-h
+        display_help();
+        Irssi::signal_stop();
+        return;
+    }
+
+    if ($key == 21) {       # Ctrl-u
+        $search_str = '';
+        update_matches();
+        update_window_select_prompt();
+
+        Irssi::signal_stop();
+        return;
+
+    }
+
+    if ($key == 127) {      # DEL
+
+        if (length $search_str) {
+            $search_str = substr($search_str, 0, -1);
+            _debug_print "Deleting char, now: $search_str";
+        }
+
+        update_matches();
+        update_window_select_prompt();
+
+        Irssi::signal_stop();
+        return;
+    }
+
+    # TODO: handle esc- sequences and arrow-keys?
+
+    if ($key == 27) {       # Esc
+        ido_switch_exit();
+        return;
+    }
+
+    if ($key == 32) {       # space
+        my $selected_win = get_window_match();
+        ido_switch_select($selected_win);
+
+        prev_match();
+        update_window_select_prompt();
+
+        Irssi::signal_stop();
+
+        return;
+    }
+
+    if ($key > 32) {        # printable
+        $search_str .= chr($key);
+
+        update_matches();
+        update_window_select_prompt();
+
+        Irssi::signal_stop();
+        return;
+    }
+
+    # ignore all other keys.
+    Irssi::signal_stop();
+}
+
+ido_switch_init();
+
+sub update_network_select_prompt {
+
+    my @servers = map
+      {
+          {
+              name => $_->{tag},
+              type => 'SERVER',
+              active => 0,
+              e_pos => -1,
+              b_pos => -1,
+              hilight_field => 'name',
+          }
+      } Irssi::servers();
+
+    my $match_count  = scalar @servers;
+    my $show_count   = $ido_show_count;
+    my $match_string = '(no matches) ';
+
+    $show_count = $match_count if $match_count < $show_count;
+
+    if ($show_count > 0) {
+        _debug_print "Showing: $show_count matches";
+
+        my @ordered_matches = _order_matches(@servers);
+        my @display = @ordered_matches[0..$show_count - 1];
+
+        # show the first entry in green
+
+        unshift(@display, _format_display_entry(shift(@display), '%g'));
+
+        # and array-slice-map the rest to be red (or yellow for active)
+        @display[1..$#display]
+          = map
+          {
+              _format_display_entry($_, $_->{active}?'%y':'%r')
+
+          } @display[1..$#display];
+
+        # join em all up
+        $match_string = join ', ', @display;
+    }
+
+    my @indicators;
+
+    # indicator if flex mode is being used (C-f to toggle)
+    push @indicators, $ido_use_flex ? 'Flex' : 'Exact';
+    push @indicators, 'Active' if $active_only;
+
+    my $flex = sprintf(' %%k[%%n%s%%k]%%n ', join ',', @indicators);
+
+    my $search = '';
+    $search = (sprintf '`%s\': ', $search_str) if length $search_str;
+
+    Irssi::signal_emit('change prompt', $flex . $search . $match_string,
+                       'UP_INNER');
+
+}


### PR DESCRIPTION
Fix several warnings of uninitialised
Only remove the lines that were drawn by ido_switcher (otherwise e.g. trackbar is killed)
Just warn about uberprompt, don't mess with script failure detection
Correctly keep track of index when using filtering after Ctrl+S
Comment out server list for now as it doesn't work (TODO) and causes errors displayed
